### PR TITLE
Upgrade scc-broker to use newer socketcluster and socketcluster-clien…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:6.3.0-slim
+FROM node:8.4.0-slim
 MAINTAINER Jonathan Gros-Dubois
 
-LABEL version="1.3.0"
+LABEL version="1.5.2"
 LABEL description="Docker file for SCC Broker Server"
 
 RUN mkdir -p /usr/src/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scc-broker",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Server for the SC cluster - For horizontal scalability.",
   "main": "server.js",
   "scripts": {
@@ -14,8 +14,8 @@
     "express": "4.13.1",
     "minimist": "1.1.0",
     "sc-framework-health-check": "~1.0.0",
-    "socketcluster": "~6.8.0",
-    "socketcluster-client": "~6.4.0"
+    "socketcluster": "~7.1.1",
+    "socketcluster-client": "~7.0.1"
   },
   "keywords": [
     "SocketCluster",


### PR DESCRIPTION
Hi,

Made a PR to upgrade scc-broker. Use newer node base-image in Dockerfile and upgrade the npm version of socketcluster and socketcluster-client