### PR TITLE
Bump Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4.0-slim
+FROM node:8-slim
 MAINTAINER Jonathan Gros-Dubois
 
 LABEL version="1.5.2"


### PR DESCRIPTION
Use tag :8-slim since version 8 of Node now is LTS:
https://github.com/nodejs/Release