### PR TITLE
Update package.json to includes uws

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "minimist": "1.2.0",
     "sc-framework-health-check": "^2.0.0",
     "socketcluster": "^11.4.1",
-    "socketcluster-client": "^11.2.0"
+    "socketcluster-client": "^11.2.0",
+    "uws": "^9.148.0"
   },
   "keywords": [
     "SocketCluster",


### PR DESCRIPTION
When trying to start the scc-broker with the command described in the clustering guide (`SCC_STATE_SERVER_HOST='127.0.0.1' SOCKETCLUSTER_PORT='8888' node server`) fails with a no module found error for `uws` after installing micro websockets it seems to start up fine.